### PR TITLE
Potential fix for code scanning alert no. 62: Unreachable `except` block

### DIFF
--- a/bin/teatime/app.py
+++ b/bin/teatime/app.py
@@ -1089,8 +1089,6 @@ class TeaTimerApp(Gtk.Application):
                 }}
                 """
             self.css_provider.load_from_data(css.encode())
-        except Exception as e:
-            print(f"Error applying font size: {e}")
 
     def _update_font_size_announcement(self):
         """Updates the accessible description for the font size buttons."""


### PR DESCRIPTION
Potential fix for [https://github.com/genidma/teatime-accessibility/security/code-scanning/62](https://github.com/genidma/teatime-accessibility/security/code-scanning/62)

The safest fix is to remove the unreachable second `except Exception as e:` block at lines 1092–1093. This preserves existing behavior (all exceptions from that `try` are already handled by the first block), eliminates dead code, and resolves the CodeQL alert without altering control flow.

Specifically in `bin/teatime/app.py`, inside `_apply_skin`, keep the first `except Exception as e:` block (lines 1081–1091) and delete the second duplicate handler (lines 1092–1093). No imports, new methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
