### PR TITLE
Potential fix for code scanning alert no. 52: Variable defined multiple times

### DIFF
--- a/bin/teatime/app.py
+++ b/bin/teatime/app.py
@@ -585,10 +585,6 @@ class TeaTimerApp(Gtk.Application):
         """Handles the activation of the about action."""
         self.show_about_dialog()
 
-    def on_toggle_sound_activated(self, action, parameter):
-        """Callback for sound toggle action."""
-        self.toggle_sound()
-
     def on_mini_mode_toggled(self, widget):
         """Callback for mini-mode toggle."""
         self.mini_mode = self.mini_mode_toggle.get_active()


### PR DESCRIPTION
Potential fix for [https://github.com/genidma/teatime-accessibility/security/code-scanning/52](https://github.com/genidma/teatime-accessibility/security/code-scanning/52)

Remove the earlier duplicate `on_toggle_sound_activated` method at lines 588–590 in `bin/teatime/app.py`, and keep the later definition at lines 1147+ as the single authoritative handler.

Why this is best:
- It resolves the redefinition warning cleanly.
- It preserves current runtime behavior (the second definition is what Python already uses).
- No imports, dependencies, or signature changes are required.
- It avoids introducing any behavioral risk by not altering the active method body.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
