### PR TITLE
Potential fix for code scanning alert no. 50: Variable defined multiple times

### DIFF
--- a/bin/teatime/app.py
+++ b/bin/teatime/app.py
@@ -44,7 +44,6 @@ class TeaTimerApp(Gtk.Application):
         self.font_scale_factor = DEFAULT_FONT_SCALE
         # Check if duration was set via environment variable
         import os
-        env_duration = os.environ.get('TEATIME_DURATION')
         # If seconds mode is active (developer/test), use duration as-is
         if getattr(self, 'use_seconds', False):
             self.last_duration = duration  # already in seconds


### PR DESCRIPTION
Potential fix for [https://github.com/genidma/teatime-accessibility/security/code-scanning/50](https://github.com/genidma/teatime-accessibility/security/code-scanning/50)

Remove the unnecessary first assignment of `env_duration` in `TeaTimerApp.__init__` and keep the existing assignment inside the `else` block, where it is actually used for normal (minutes) mode.

Best fix (no functionality change):
- In `bin/teatime/app.py`, within `__init__` near lines 45–54:
  - Delete `env_duration = os.environ.get('TEATIME_DURATION')` at line 47.
- Keep the `else` branch assignment at current line 53 as-is.
- No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
