### PR TITLE
Potential fix for code scanning alert no. 75: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -6,6 +6,9 @@ on:
       - main
       - 'photosensitive-version'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/genidma/teatime-accessibility/security/code-scanning/75](https://github.com/genidma/teatime-accessibility/security/code-scanning/75)

Add an explicit `permissions` block to `.github/workflows/build-snap.yml` at the workflow root (preferred here since there is one job), setting only the minimum needed scope:

- `contents: read`

This preserves existing functionality while documenting and enforcing least privilege for `GITHUB_TOKEN`.  
Edit region: immediately after the `on:` trigger block and before `jobs:`.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
