### PR TITLE
Potential fix for code scanning alert no. 74: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -6,6 +6,9 @@ on:
       - main
       - 'photosensitive-version'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Flatpak"


### PR DESCRIPTION
Potential fix for [https://github.com/genidma/teatime-accessibility/security/code-scanning/74](https://github.com/genidma/teatime-accessibility/security/code-scanning/74)

Add an explicit `permissions` block to `.github/workflows/build-flatpak.yml` so the workflow does not rely on repository/org defaults.  
Best minimal fix (without changing functionality): set workflow-level permissions to:

- `contents: read`

This grants enough for `actions/checkout@v4` to read repository contents and keeps token scope least-privileged for the shown steps.

Edit location: near the top of `.github/workflows/build-flatpak.yml`, after the `on:` trigger block and before `jobs:`.

No imports, methods, or external definitions are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
