### PR TITLE
Potential fix for code scanning alert no. 36: File is not always closed

### DIFF
--- a/bin/teatime-tasks-priority-test.py
+++ b/bin/teatime-tasks-priority-test.py
@@ -552,7 +552,7 @@ def main():
                                         server_cmd = [sys.executable, '-m', 'http.server', str(port)]
                                         try:
                                             # open the log file via fd, pass it to the subprocess, and close in parent
-                                            log_fd = os.open(log_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+                                            log_fd = os.open(log_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
                                             try:
                                                 os.write(log_fd, (f"[{datetime.now().isoformat()}] Starting local HTTP server: {' '.join(server_cmd)} (cwd={tmp_dir})\n").encode())
                                                 server_proc = subprocess.Popen(server_cmd, cwd=tmp_dir, stdout=log_fd, stderr=log_fd)

--- a/bin/teatime-tasks-priority-test.py
+++ b/bin/teatime-tasks-priority-test.py
@@ -551,11 +551,13 @@ def main():
                                         s.close()
                                         server_cmd = [sys.executable, '-m', 'http.server', str(port)]
                                         try:
-                                            # open the log file and keep the handle open for the server subprocess
-                                            server_logf = open(log_path, 'ab')
-                                            server_logf.write((f"[{datetime.now().isoformat()}] Starting local HTTP server: {' '.join(server_cmd)} (cwd={tmp_dir})\n").encode())
-                                            server_logf.flush()
-                                            server_proc = subprocess.Popen(server_cmd, cwd=tmp_dir, stdout=server_logf, stderr=server_logf)
+                                            # open the log file via fd, pass it to the subprocess, and close in parent
+                                            log_fd = os.open(log_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+                                            try:
+                                                os.write(log_fd, (f"[{datetime.now().isoformat()}] Starting local HTTP server: {' '.join(server_cmd)} (cwd={tmp_dir})\n").encode())
+                                                server_proc = subprocess.Popen(server_cmd, cwd=tmp_dir, stdout=log_fd, stderr=log_fd)
+                                            finally:
+                                                os.close(log_fd)
                                             # give server a moment to start
                                             time.sleep(0.2)
                                             http_url = f'http://127.0.0.1:{port}/gantt-chart.html'
@@ -567,7 +569,6 @@ def main():
                                                 pass
                                             # Replace file_url with http_url so Chromium opens HTTP endpoint
                                             file_url = http_url
-                                            # Note: server_logf intentionally not closed here so the server keeps writing to the file
                                             # And set a short timeout for server liveness check later if needed
                                         except Exception as e:
                                             print(f"Failed to start local HTTP server fallback: {e}")


### PR DESCRIPTION
Potential fix for [https://github.com/genidma/teatime-accessibility/security/code-scanning/36](https://github.com/genidma/teatime-accessibility/security/code-scanning/36)

Use a file descriptor opened via `os.open(...)` and pass that descriptor directly to `subprocess.Popen` for `stdout`/`stderr`, then close the descriptor in the parent immediately with `os.close(...)` in a `finally` block. This preserves behavior (child keeps writing to the same log file) while ensuring no leaked Python file object/descriptor remains in the parent.

In `bin/teatime-tasks-priority-test.py`, replace the block where `server_logf = open(log_path, 'ab')`, writes startup text, flushes, and passes `server_logf` to `Popen`.  
Specifically in the shown region around lines 555–571:
- Replace `open(log_path, 'ab')` usage with `log_fd = os.open(log_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)`.
- Write the startup line using `os.write(log_fd, ...)`.
- Pass `log_fd` to `subprocess.Popen(..., stdout=log_fd, stderr=log_fd)`.
- Ensure parent closes `log_fd` in `finally` via `os.close(log_fd)`.

No new imports are needed since `os` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
