### PR TITLE
Potential fix for code scanning alert no. 53: Potentially uninitialized local variable

### DIFF
--- a/bin/teatime/stats.py
+++ b/bin/teatime/stats.py
@@ -488,7 +488,7 @@ class StatisticsWindow(Gtk.Window):
             # Use idle_add to ensure the UI is fully initialized before starting
             GLib.idle_add(self._auto_start_timer)
 
-            self.window.add(main_box)
+            self.window.add(self.main_box)
 
         self.window.show_all()
 


### PR DESCRIPTION
Potential fix for [https://github.com/genidma/teatime-accessibility/security/code-scanning/53](https://github.com/genidma/teatime-accessibility/security/code-scanning/53)

General fix: avoid using a local variable that is conditionally initialized outside its guaranteed scope. Use a persistent instance attribute initialized during UI creation (`self.main_box`) or guard usage by ensuring initialization in all paths.

Best fix here (without changing intended behavior): in `do_activate`, replace `self.window.add(main_box)` at line 491 with `self.window.add(self.main_box)`. This removes the uninitialized-local risk and uses the already stored widget reference. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
