### PR TITLE
Potential fix for code scanning alert no. 72: Unused import

### DIFF
--- a/archives/issue83-gh/direct_test.py
+++ b/archives/issue83-gh/direct_test.py
@@ -8,7 +8,6 @@ sys.path.append(os.path.join(os.path.dirname(__file__), 'bin'))
 from teatime import TeaTimerApp
 import gi
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, GLib
 
 class TestApp(TeaTimerApp):
     def __init__(self):


### PR DESCRIPTION
Potential fix for [https://github.com/genidma/teatime-accessibility/security/code-scanning/72](https://github.com/genidma/teatime-accessibility/security/code-scanning/72)

Remove the unused `from gi.repository import Gtk, GLib` line from `archives/issue83-gh/direct_test.py`.

- **General fix approach:** delete imports that are never referenced in the module.
- **Best specific fix here:** keep `import gi` and `gi.require_version("Gtk", "3.0")` (since version pinning may still be needed by transitive GTK usage inside `TeaTimerApp`), and remove only the unused symbol import.
- **Where to change:** `archives/issue83-gh/direct_test.py`, around lines 9–11.
- **What is needed:** no new methods, no new definitions, no new imports.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
