### PR TITLE
Potential fix for code scanning alert no. 57: Unused import

### DIFF
--- a/bin/teatime/app.py
+++ b/bin/teatime/app.py
@@ -15,7 +15,7 @@ import sys
 import gi
 # Use GTK 3 for better compatibility
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, GLib, Gio, Gdk, Pango, GdkPixbuf
+from gi.repository import Gtk, GLib, Gio, Gdk, GdkPixbuf
 
 import argparse
 


### PR DESCRIPTION
Potential fix for [https://github.com/genidma/teatime-accessibility/security/code-scanning/57](https://github.com/genidma/teatime-accessibility/security/code-scanning/57)

Remove `Pango` from the `gi.repository` import list in `bin/teatime/app.py`, leaving all actually used GTK-related imports unchanged. This is the minimal, behavior-preserving fix: it does not alter runtime logic, only removes an unnecessary dependency reference.

Concretely:
- File: `bin/teatime/app.py`
- Region: import section near line 18
- Change:
  - From: `from gi.repository import Gtk, GLib, Gio, Gdk, Pango, GdkPixbuf`
  - To:   `from gi.repository import Gtk, GLib, Gio, Gdk, GdkPixbuf`

No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
