### PR TITLE
Potential fix for code scanning alert no. 26: Empty except

### DIFF
--- a/bin/teatime-tasks-priority-test.py
+++ b/bin/teatime-tasks-priority-test.py
@@ -427,8 +427,9 @@ def main():
                 try:
                     with open('/tmp/tt-gantt-debug.log', 'ab') as df:
                         df.write((f"[{datetime.now().isoformat()}] Auto-open envs: OPEN_GANTT={open_env}, BROWSER_NAME={browser_override}, ALLOW_NO_SANDBOX={os.getenv('ALLOW_NO_SANDBOX')}\n").encode())
-                except Exception:
-                    pass
+                except Exception as e:
+                    # Best-effort debug logging must not interrupt execution.
+                    print(f"DEBUG: could not write /tmp/tt-gantt-debug.log: {e}")
                 try:
                     # Use filesystem path for subprocess invocations to avoid ERR_FILE_NOT_FOUND
                     file_path = os.path.abspath(gantt_path)


### PR DESCRIPTION
Potential fix for [https://github.com/genidma/teatime-accessibility/security/code-scanning/26](https://github.com/genidma/teatime-accessibility/security/code-scanning/26)

The best fix is to keep the debug-log write as best-effort (so functionality does not change), but avoid a truly empty `except` block.  
In `bin/teatime-tasks-priority-test.py`, update the `except Exception:` around the `/tmp/tt-gantt-debug.log` write to capture the exception object and print a short, non-fatal message explaining that debug logging failed.

This preserves existing behavior (script continues), improves observability, and satisfies the static analysis requirement by ensuring the handler does something meaningful.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
