### PR TITLE
Potential fix for code scanning alert no. 28: Empty except

### DIFF
--- a/bin/teatime-tasks-priority-test.py
+++ b/bin/teatime-tasks-priority-test.py
@@ -508,8 +508,8 @@ def main():
                                     try:
                                         with open('/tmp/tt-gantt-debug.log', 'ab') as df:
                                             df.write((f"[{datetime.now().isoformat()}] Created {tmp_dir} and copied to {tmp_copy_path}\n").encode())
-                                    except Exception:
-                                        pass
+                                    except Exception as log_err:
+                                        print(f"Warning: failed to write debug log: {log_err}", file=sys.stderr)
                                 except Exception as e:
                                     # If copy fails, fall back to original file path but log clearly.
                                     print(f"Failed to copy gantt file to {tmp_copy_path}: {e}")


### PR DESCRIPTION
Potential fix for [https://github.com/genidma/teatime-accessibility/security/code-scanning/28](https://github.com/genidma/teatime-accessibility/security/code-scanning/28)

To fix this safely without changing functionality, keep the “do not fail main flow if debug logging fails” behavior, but replace the empty `except` body with a minimal explanatory action (for example, writing a warning to `stderr`). This preserves resilience while avoiding silent failure.

Best change in this snippet:
- In `bin/teatime-tasks-priority-test.py`, replace the empty block at lines 511–512 with a non-empty handler that records the logging failure reason.
- Use existing `sys` import (already present at line 32), so no new imports are needed.
- Capture the exception as `log_err` and emit one concise warning to `sys.stderr`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
