### PR TITLE
Potential fix for code scanning alert no. 18: Unused import

### DIFF
--- a/archives/create_gif.py
+++ b/archives/create_gif.py
@@ -5,7 +5,6 @@ Script to create a GIF from sprite frames.
 
 from PIL import Image
 import glob
-import os
 
 def create_gif():
     # Get all sprite frames


### PR DESCRIPTION
Potential fix for [https://github.com/genidma/teatime-accessibility/security/code-scanning/18](https://github.com/genidma/teatime-accessibility/security/code-scanning/18)

To fix this, remove the unused `import os` line from `archives/create_gif.py`.

Best single fix without changing functionality:
- In `archives/create_gif.py`, in the import section at the top, delete line 8 (`import os`).
- No other code changes are needed because no part of the script references `os`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
