### PR TITLE
Potential fix for code scanning alert no. 34: Empty except

### DIFF
--- a/bin/teatime-tasks-priority-test.py
+++ b/bin/teatime-tasks-priority-test.py
@@ -616,8 +616,8 @@ def main():
                                     try:
                                         with open('/tmp/tt-gantt-debug.log', 'ab') as df:
                                             df.write((f"[{datetime.now().isoformat()}] Launch failed: {e}\n").encode())
-                                    except Exception:
-                                        pass
+                                    except Exception as log_err:
+                                        print(f"Non-fatal: could not write debug log '/tmp/tt-gantt-debug.log': {log_err}", file=sys.stderr)
                         else:
                             try:
                                 webbrowser.get(browser_override).open_new_tab(file_url)


### PR DESCRIPTION
Potential fix for [https://github.com/genidma/teatime-accessibility/security/code-scanning/34](https://github.com/genidma/teatime-accessibility/security/code-scanning/34)

The best fix is to keep the current fault-tolerant behavior (do not crash if debug logging itself fails) but replace the empty `except` with a minimal, explicit handling action.

In `bin/teatime-tasks-priority-test.py`, in the block around lines 616–620, change:

- `except Exception: pass`

to:

- `except Exception as log_err:` followed by a short `print(...)` to `sys.stderr` explaining that writing the debug log failed.

This preserves existing functionality (script continues running), avoids silent exception swallowing, and provides observability for debugging. No new imports are needed because `sys` is already imported in the shown snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
