### PR TITLE
Potential fix for code scanning alert no. 61: Except block handles 'BaseException'

### DIFF
--- a/bin/teatime/app.py
+++ b/bin/teatime/app.py
@@ -782,7 +782,7 @@ class TeaTimerApp(Gtk.Application):
                 try:
                     print("\a", end="", flush=True)
                     return True
-                except:
+                except Exception:
                     return False
 
             strategies = [strategy_paplay, strategy_aplay, strategy_system_beep]


### PR DESCRIPTION
Potential fix for [https://github.com/genidma/teatime-accessibility/security/code-scanning/61](https://github.com/genidma/teatime-accessibility/security/code-scanning/61)

Use a specific exception type instead of a bare `except:` in `strategy_system_beep()`.

Best fix (no functional change intended): in `bin/teatime/app.py`, change line 785 from `except:` to `except Exception:`. This keeps the existing fallback behavior (`return False` on normal errors) while allowing `KeyboardInterrupt` and `SystemExit` to propagate correctly.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
