### PR TITLE
Potential fix for code scanning alert no. 73: Overwriting attribute in super-class or sub-class

### DIFF
--- a/archives/issue83-gh/direct_test.py
+++ b/archives/issue83-gh/direct_test.py
@@ -11,10 +11,8 @@ gi.require_version("Gtk", "3.0")
 
 class TestApp(TeaTimerApp):
     def __init__(self):
-        # Initialize superclass state first
-        super().__init__()
-        # Override for this direct test
-        self.current_timer_duration = 5  # 5 minutes
+        # Initialize superclass state with direct-test duration
+        super().__init__(current_timer_duration=5)  # 5 minutes
         
     def test_logging(self):
         print("Testing _log_timer_completion directly...")

--- a/archives/issue83-gh/direct_test.py
+++ b/archives/issue83-gh/direct_test.py
@@ -12,7 +12,7 @@ gi.require_version("Gtk", "3.0")
 class TestApp(TeaTimerApp):
     def __init__(self):
         # Initialize superclass state with direct-test duration
-        super().__init__(current_timer_duration=5)  # 5 minutes
+        super().__init__(5)  # 5 minutes
         
     def test_logging(self):
         print("Testing _log_timer_completion directly...")


### PR DESCRIPTION
Potential fix for [https://github.com/genidma/teatime-accessibility/security/code-scanning/73](https://github.com/genidma/teatime-accessibility/security/code-scanning/73)

To fix this without changing behavior, avoid assigning `current_timer_duration` in the subclass body. Instead, pass the test-specific duration to the superclass constructor so the superclass remains the single owner of that attribute’s initialization.

In `archives/issue83-gh/direct_test.py`, update `TestApp.__init__`:
- Replace `super().__init__()` plus `self.current_timer_duration = 5` with a single `super().__init__(current_timer_duration=5)` call.
- Keep comments aligned to indicate this is test-specific configuration passed to superclass initialization.

No new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
