### PR TITLE
Potential fix for code scanning alert no. 59: Unused import

### DIFF
--- a/bin/teatime/stats.py
+++ b/bin/teatime/stats.py
@@ -5,7 +5,7 @@ import json
 import gi
 # Use GTK 3 for better compatibility
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, GLib, Gio, Gdk, Pango, GdkPixbuf
+from gi.repository import Gtk, GLib, Gdk
 
 from .core import STATS_LOG_FILE, StatsManager
 


### PR DESCRIPTION
Potential fix for [https://github.com/genidma/teatime-accessibility/security/code-scanning/59](https://github.com/genidma/teatime-accessibility/security/code-scanning/59)

Remove unused modules from the `gi.repository` import line in `bin/teatime/stats.py` while keeping used imports intact.

Best single fix without changing behavior:
- In `bin/teatime/stats.py`, edit line 8 import statement.
- Keep `Gtk`, `GLib`, and `Gdk` (they are used in the snippet).
- Remove `Gio`, `Pango`, and `GdkPixbuf` (flagged and unused).
- No other code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
