### PR TITLE
Potential fix for code scanning alert no. 58: Unused import

### DIFF
--- a/bin/teatime/app.py
+++ b/bin/teatime/app.py
@@ -29,7 +29,6 @@ from .core import (
     MIN_FONT_SCALE,
     MAX_FONT_SCALE,
     ConfigManager,
-    StatsManager,
 )
 from .stats import StatisticsWindow
 


### PR DESCRIPTION
Potential fix for [https://github.com/genidma/teatime-accessibility/security/code-scanning/58](https://github.com/genidma/teatime-accessibility/security/code-scanning/58)

To fix this unused import issue without changing behavior, remove `StatsManager` from the `from .core import (...)` list in `bin/teatime/app.py`.

Best single change:
- In `bin/teatime/app.py`, edit the `.core` grouped import block (lines 22–33 in the snippet).
- Delete only the `StatsManager,` entry.
- Keep all other imported names unchanged.

No new methods, definitions, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
